### PR TITLE
Feat `onReportError`, `onFlushError`, `formatFetchError`

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,17 @@ export interface YaVigilReporterOptions {
   /** (legacy) Alias of `logger` options */
   console?: YaVigilReporterLogger | undefined | null;
 
-  /** OnTick */
+  /** On Tick */
   onTick?: (data: YaVigilReportResult) => void;
+
+  /** On Report Error */
+  onReportError?: (error: unknown) => void;
+
+  /** On Fetch Error */
+  onFlushError?: (error: unknown) => void;
+
+  /** Format the fetch error message */
+  formatFetchError?: (resp: Response) => Promise<string> | string;
 }
 ```
 

--- a/src/models/ya-vigil-reporter-options.ts
+++ b/src/models/ya-vigil-reporter-options.ts
@@ -37,8 +37,17 @@ export interface YaVigilReporterOptions {
   /** (legacy) Alias of `logger` options */
   console?: YaVigilReporterLogger | undefined | null;
 
-  /** OnTick */
+  /** On Tick */
   onTick?: (data: YaVigilReportResult) => void;
+
+  /** On Report Error */
+  onReportError?: (error: unknown) => void;
+
+  /** On Fetch Error */
+  onFlushError?: (error: unknown) => void;
+
+  /** Format the fetch error message */
+  formatFetchError?: (resp: Response) => Promise<string> | string;
 }
 
 export interface YaVigilReportResult {

--- a/src/tests/create-fake-vigil-server.spec.ts
+++ b/src/tests/create-fake-vigil-server.spec.ts
@@ -30,6 +30,10 @@ export function createFakeVigilServer() {
       if (probe_id === 'invalid') {
         throw new Error('Invalid probe_id!');
       }
+      if (probe_id === 'invalid_whtml') {
+        reply.status(405).type('text/html').send('<html><head></head><body>Not mutant allowed</body></html>');
+        return;
+      }
       if (node_id === 'invalid') {
         throw new Error('Invalid node_id!');
       }
@@ -59,6 +63,10 @@ export function createFakeVigilServer() {
       }
       if (probe_id === 'invalid') {
         throw new Error('Invalid probe_id!');
+      }
+      if (probe_id === 'invalid_whtml') {
+        reply.status(405).type('text/html').send('<html><head></head><body>Not mutant allowed</body></html>');
+        return;
       }
       if (node_id === 'invalid') {
         throw new Error('Invalid node_id!');


### PR DESCRIPTION
New constructor options:

```typescript
/** On Report Error */
onReportError?: (error: unknown) => void;

/** On Fetch Error */
onFlushError?: (error: unknown) => void;

/** Format the fetch error message */
formatFetchError?: (resp: Response) => Promise<string> | string;
```

Change:
- Before, the fetch error message followed this format: `{statusText} (${status}): ${respText}`.
- Now, the fetch error message follows this format: if the contentType is HTML, then it's `${statusText} (${status})`, otherwise it's `${statusText} (${status}): ${respText}`.